### PR TITLE
add scripts to watch a pretrained network play

### DIFF
--- a/dqn/test_agent.lua
+++ b/dqn/test_agent.lua
@@ -1,0 +1,82 @@
+--[[
+Copyright (c) 2014 Google Inc.
+
+See LICENSE file for full terms of limited license.
+]]
+
+if not dqn then
+    require "initenv"
+end
+
+local cmd = torch.CmdLine()
+cmd:text()
+cmd:text('Train Agent in Environment:')
+cmd:text()
+cmd:text('Options:')
+
+cmd:option('-framework', '', 'name of training framework')
+cmd:option('-env', '', 'name of environment to use')
+cmd:option('-game_path', '', 'path to environment file (ROM)')
+cmd:option('-env_params', '', 'string of environment parameters')
+cmd:option('-pool_frms', '',
+           'string of frame pooling parameters (e.g.: size=2,type="max")')
+cmd:option('-actrep', 1, 'how many times to repeat action')
+cmd:option('-random_starts', 0, 'play action 0 between 1 and random_starts ' ..
+           'number of times at the start of each training episode')
+
+cmd:option('-name', '', 'filename used for saving network and training history')
+cmd:option('-network', '', 'reload pretrained network')
+cmd:option('-agent', '', 'name of agent file to use')
+cmd:option('-agent_params', '', 'string of agent parameters')
+cmd:option('-seed', 1, 'fixed input seed for repeatable experiments')
+cmd:option('-saveNetworkParams', false,
+           'saves the agent network in a separate file')
+cmd:option('-prog_freq', 5*10^3, 'frequency of progress output')
+cmd:option('-save_freq', 5*10^4, 'the model is saved every save_freq steps')
+cmd:option('-eval_freq', 10^4, 'frequency of greedy evaluation')
+cmd:option('-save_versions', 0, '')
+
+cmd:option('-steps', 10^5, 'number of training steps to perform')
+cmd:option('-eval_steps', 10^5, 'number of evaluation steps')
+
+cmd:option('-verbose', 2,
+           'the higher the level, the more information is printed to screen')
+cmd:option('-threads', 1, 'number of BLAS threads')
+cmd:option('-gpu', -1, 'gpu flag')
+cmd:option('-ep', 0.0, 'exploration probability')
+
+cmd:text()
+
+local opt = cmd:parse(arg)
+
+--- General setup.
+local game_env, game_actions, agent, opt = setup(opt)
+
+-- override print to always flush the output
+local old_print = print
+local print = function(...)
+    old_print(...)
+    io.flush()
+end
+
+local step = 0
+
+local screen, reward, terminal = game_env:getState()
+
+print("Running...")
+local win = nil
+while step < opt.steps do
+    step = step + 1
+    local action_index = agent:perceive(reward, screen, terminal, true, opt.ep)
+
+    -- game over? get next game!
+    if not terminal then
+        screen, reward, terminal = game_env:step(game_actions[action_index], true)
+    else
+        screen, reward, terminal = game_env:newGame()
+    end
+
+    -- display screen
+    win = image.display({image=screen, win=win})
+
+end

--- a/watch_pretrained
+++ b/watch_pretrained
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then echo "Please provide the name of the game, e.g.  ./view_pretrained breakout"; exit 0
+fi
+
+if [ -z "$2" ]
+  then echo "Please provide the pretrained network file, e.g.  ./view_pretrained breakout DQN3_0_1_breakout_FULL_Y"; exit 0
+fi
+
+ENV=$1
+NETWORK=$2
+FRAMEWORK="alewrap"
+
+EP=0.0 # for visualizing exploration probability
+if [ ! -z "$3" ]; then
+  EP=$3
+fi
+
+game_path=$PWD"/roms/"
+env_params="useRGB=true"
+agent="NeuralQLearner"
+n_replay=1
+netfile="\"convnet_atari3\""
+update_freq=4
+actrep=4
+discount=0.99
+seed=1
+learn_start=50000
+pool_frms_type="\"max\""
+pool_frms_size=2
+initial_priority="false"
+replay_memory=1000000
+eps_end=0.1
+eps_endt=replay_memory
+lr=0.00025
+agent_type="DQN3_0_1"
+preproc_net="\"net_downsample_2x_full_y\""
+agent_name=$agent_type"_"$1"_FULL_Y"
+state_dim=7056
+ncols=1
+agent_params="lr="$lr",ep=1,ep_end="$eps_end",ep_endt="$eps_endt",discount="$discount",hist_len=4,learn_start="$learn_start",replay_memory="$replay_memory",update_freq="$update_freq",n_replay="$n_replay",network="$netfile",preproc="$preproc_net",state_dim="$state_dim",minibatch_size=32,rescale_r=1,ncols="$ncols",bufferSize=512,valid_size=500,target_q=10000,clip_delta=1,min_reward=-1,max_reward=1"
+steps=50000000
+eval_freq=250000
+eval_steps=125000
+prog_freq=10000
+save_freq=125000
+gpu=1
+random_starts=30
+pool_frms="type="$pool_frms_type",size="$pool_frms_size
+num_threads=4
+
+args="-framework $FRAMEWORK -game_path $game_path -name $agent_name -env $ENV -env_params $env_params -agent $agent -agent_params $agent_params -steps $steps -eval_freq $eval_freq -eval_steps $eval_steps -prog_freq $prog_freq -save_freq $save_freq -actrep $actrep -gpu $gpu -random_starts $random_starts -pool_frms $pool_frms -seed $seed -threads $num_threads -network $NETWORK -ep $EP"
+echo $args
+
+cd dqn
+qlua test_agent.lua $args


### PR DESCRIPTION
Removes the exploration probability component when running pretrained networks, thus allowing visualization of pretrained networks. 
