### PR TITLE
Fixed install_depends.sh to work in multiuser environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,29 @@ Tested on Ubuntu 14.04 with nVidia GTX 970:
 ![alt text](https://raw.githubusercontent.com/kuz/DeepMind-Atari-Deep-Q-Learner/master/gifs/breakout.gif "Playing Breakout")  
 More videos on [YouTube Playlist: Deepmind DQN Playing](https://www.youtube.com/playlist?list=PLgOp827qARy0qNyZq5Y6S6vRJO3tb1WcW)
 
+Dependencies
+------------
+These package names are valid for Ubuntu 14.04.
+You should install them before running the `install_dependencies.sh` script.
+* build-essential
+* gcc
+* g++
+* cmake
+* curl
+* libreadline-dev
+* git-core
+* libjpeg-dev
+* libpng-dev
+* ncurses-dev
+* imagemagick
+* unzip
+* libqt4-dev
+* liblua5.1-0-dev
+* libgd-dev
+
+
+
+
 DQN 3.0
 -------
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -11,42 +11,16 @@ TOPDIR=$PWD
 PREFIX=$PWD/torch
 echo "Installing Torch into: $PREFIX"
 
-if [[ `uname` != 'Linux' ]]; then
+if [[ $(uname) != 'Linux' ]]; then
   echo 'Platform unsupported, only available for Linux'
   exit
 fi
-if [[ `which apt-get` == '' ]]; then
-    echo 'apt-get not found, platform not supported'
-    exit
-fi
 
-# Install dependencies for Torch:
-sudo apt-get update
-sudo apt-get install -qqy build-essential
-sudo apt-get install -qqy gcc g++
-sudo apt-get install -qqy cmake
-sudo apt-get install -qqy curl
-sudo apt-get install -qqy libreadline-dev
-sudo apt-get install -qqy git-core
-sudo apt-get install -qqy libjpeg-dev
-sudo apt-get install -qqy libpng-dev
-sudo apt-get install -qqy ncurses-dev
-sudo apt-get install -qqy imagemagick
-sudo apt-get install -qqy unzip
-sudo apt-get install -qqy libqt4-dev
-sudo apt-get install -qqy liblua5.1-0-dev
-sudo apt-get install -qqy libgd-dev
-sudo apt-get update
-
-
-echo "==> Torch7's dependencies have been installed"
-
-
-
-
+BASEDIR=/tmp/$USER
+mkdir -p $BASEDIR
 
 # Build and install Torch7
-cd /tmp
+cd $BASEDIR
 rm -rf luajit-rocks
 git clone https://github.com/torch/luajit-rocks.git
 cd luajit-rocks
@@ -100,7 +74,7 @@ RET=$?; if [ $RET -ne 0 ]; then echo "Error. Exiting."; exit $RET; fi
 echo "nngraph installation completed"
 
 echo "Installing Xitari ... "
-cd /tmp
+cd $BASEDIR
 rm -rf xitari
 git clone https://github.com/deepmind/xitari.git
 cd xitari
@@ -109,7 +83,7 @@ RET=$?; if [ $RET -ne 0 ]; then echo "Error. Exiting."; exit $RET; fi
 echo "Xitari installation completed"
 
 echo "Installing Alewrap ... "
-cd /tmp
+cd $BASEDIR
 rm -rf alewrap
 git clone https://github.com/deepmind/alewrap.git
 cd alewrap


### PR DESCRIPTION
Removed 'sudo apt-get install dependency' to the README
because one may not have sudo.
Moved temp directory to /tmp/$USER because $USER
may not be the only one using this script.
